### PR TITLE
Use Windows compatible code for terminal coloring

### DIFF
--- a/ronin/utils/messages.py
+++ b/ronin/utils/messages.py
@@ -16,7 +16,6 @@
 
 from __future__ import unicode_literals
 from .unicode import to_str
-from blessings import Terminal
 import colorama, atexit
 
 
@@ -27,7 +26,12 @@ def _restore_terminal():
     
 atexit.register(_restore_terminal)
 
-terminal = Terminal()
+colors = {
+    'green': colorama.Fore.GREEN,
+    'red': colorama.Fore.RED,
+    'yellow': colorama.Fore.YELLOW,
+}
+reset_color = colorama.Style.RESET_ALL
 
 
 def announce(message, prefix='rōnin', color='green'):
@@ -39,9 +43,9 @@ def announce(message, prefix='rōnin', color='green'):
     :param color: color name
     :type color: str
     """
-    
-    if color:
-        prefix = getattr(terminal, color)(prefix)
+
+    if color and color in colors:
+        prefix = colors[color] + prefix + reset_color
     print('{}: {}'.format(prefix, message))
 
 

--- a/ronin/utils/platform.py
+++ b/ronin/utils/platform.py
@@ -212,6 +212,16 @@ def which(command, exception=True):
             raise WhichException("could not find '{}'".format(command))
         return None
 
+def shutil_which(command, exception=True):
+    import shutil
+    command = stringify(command)
+    found_command = shutil.which(command)
+    if found_command is None:
+        if exception:
+            raise WhichException("could not find '{}'".format(command))
+        return None
+    return found_command
+
 
 class WhichException(Exception):
     """

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ try:
     import pypandoc # @UnresolvedImport
     long_description = pypandoc.convert(os.path.join(HERE, 'README.md'), 'rst')
 except(IOError, ImportError):
-    with io.open(os.path.join(HERE, 'README.md')) as f:
+    with io.open(os.path.join(HERE, 'README.md'), encoding='utf8') as f:
         long_description = f.read()
 
 with io.open(os.path.join(HERE, 'ronin', 'version.py')) as f:
@@ -74,6 +74,5 @@ setup(
               'ronin.vala'),
     
     install_requires=(
-        'blessings>=1.6, <2.0',
         'colorama>=0.3.9, <2.0.0',
         'glob2>=0.5, <=2.0'))


### PR DESCRIPTION
Well here are my suggestions to remove the dependency on blessings.
I also needed to specify the encoding in setup.py to be able to install from source.

Fixes #4 